### PR TITLE
fix set maximum incoming connections bug.

### DIFF
--- a/src/RakServer.cpp
+++ b/src/RakServer.cpp
@@ -127,12 +127,12 @@ Napi::Value RakServer::Listen(const Napi::CallbackInfo& info) {
     socketDescriptors[1].port = this->port;
     socketDescriptors[1].socketFamily = AF_INET6;
     //TODO: fix ipv6
-    bool b = server->Startup(4, socketDescriptors, 2) == RakNet::RAKNET_STARTED;
+    bool b = server->Startup(this->options.maxConnections, socketDescriptors, 2) == RakNet::RAKNET_STARTED;
     if (!b) {
         printf("Failed to start dual IPV4 and IPV6 ports. Trying IPV4 only.\n");
 
         // Try again, but leave out IPV6
-        b = server->Startup(4, socketDescriptors, 1) == RakNet::RAKNET_STARTED;
+        b = server->Startup(this->options.maxConnections, socketDescriptors, 1) == RakNet::RAKNET_STARTED;
         if (!b) {
             Napi::TypeError::New(env, "Server failed to start").ThrowAsJavaScriptException();
             return Napi::Boolean::New(env, false);


### PR DESCRIPTION
server->Startup setting error caused SetMaximumIncomingConnections to not take effect.

only accept to 4 connections.

![1640409208(1)](https://user-images.githubusercontent.com/35518985/147378757-4eeff8e3-7945-4e81-885e-a10208b974d5.png)

![1640409238(1)](https://user-images.githubusercontent.com/35518985/147378759-aca0ecab-8bc1-40b3-ba6b-6c0baafc9c90.png)

![1640409264(1)](https://user-images.githubusercontent.com/35518985/147378761-9676ab08-f71b-4af1-8bad-14cb935f9580.png)
